### PR TITLE
Fix Markdown of Heroku Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   
 
 <div align="center">
-**Try it at: [liveview-chat-example.herokuapp](https://liveview-chat-example.herokuapp.com/)**
+**Try it**: [**liveview-chat-example.herokuapp**](https://liveview-chat-example.herokuapp.com/)
 </div>
 
 ## Content

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # LiveviewChat
 
-[![Elixir CI](https://github.com/dwyl/phoenix-liveview-chat-example/actions/workflows/cy.yml/badge.svg)](https://github.com/dwyl/phoenix-liveview-chat-example/actions/workflows/cy.yml)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/dwyl/phoenix-liveview-chat-example/Elixir%20CI?label=build&style=flat-square)](https://github.com/dwyl/phoenix-liveview-chat-example/actions/workflows/cy.yml)
 [![HitCount](http://hits.dwyl.com/dwyl/phoenix-liveview-chat-example.svg?style=flat-square)](http://hits.dwyl.com/dwyl/phoenix-liveview-chat-example)
   
 **Try it**: [**liveview-chat-example.herokuapp**](https://liveview-chat-example.herokuapp.com)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
+<div align="center">
+
 # LiveviewChat
 
 [![Elixir CI](https://github.com/dwyl/phoenix-liveview-chat-example/actions/workflows/cy.yml/badge.svg)](https://github.com/dwyl/phoenix-liveview-chat-example/actions/workflows/cy.yml)
-  [![HitCount](http://hits.dwyl.com/dwyl/phoenix-liveview-chat-example.svg?style=flat-square)](http://hits.dwyl.com/dwyl/phoenix-liveview-chat-example)
-  
-
-<div align="center">
+[![HitCount](http://hits.dwyl.com/dwyl/phoenix-liveview-chat-example.svg?style=flat-square)](http://hits.dwyl.com/dwyl/phoenix-liveview-chat-example)
   
 **Try it**: [**liveview-chat-example.herokuapp**](https://liveview-chat-example.herokuapp.com)
   

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
   
 
 <div align="center">
-**Try it**: [**liveview-chat-example.herokuapp**]("https://liveview-chat-example.herokuapp.com")
+  
+**Try it**: [**liveview-chat-example.herokuapp**](https://liveview-chat-example.herokuapp.com)
+  
 </div>
 
 ## Content

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   
 
 <div align="center">
-**Try it**: [**liveview-chat-example.herokuapp**](https://liveview-chat-example.herokuapp.com/)
+**Try it**: [**liveview-chat-example.herokuapp**]("https://liveview-chat-example.herokuapp.com")
 </div>
 
 ## Content


### PR DESCRIPTION
<img width="989" alt="heroku-link-markdown-fail" src="https://user-images.githubusercontent.com/194400/143132604-e7ff6850-f897-45c6-9abf-66822471a8d7.png">

![image](https://user-images.githubusercontent.com/194400/143132623-6e475194-21ff-4ab7-845b-2bf8a551e679.png)

This PR fixes that. 