### PR TITLE
use temporary assigns to minimise memory used

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Migration and Schema](#migration-and-schema)
 - [Handle events](#handle-events)
 - [PubSub](#pubsub)
+- [Temporary assigns](#temporary-assigns)
 - [What's next](#whats-next)
  
 ## Initialisation
@@ -476,7 +477,7 @@ You should now have a functional chat application using liveView!
 ## Temporary assigns
 
 At the moment the `mount` function first initialise the list of messages
-by loading the latest 20 messsages from the database:
+by loading the latest 20 messages from the database:
 
 ```elixir
 def mount(_params, _session, socket) do
@@ -499,7 +500,7 @@ def handle_info({:message_created, message}, socket) do
 end
 ```
 
-This can cause issues if the list of messages become long as
+This can cause issues if the list of messages becomes too long as
 all the messages are kept in memory on the server.
 
 To minimise the use of the memory we can define messages as a temporary assign:
@@ -528,8 +529,8 @@ Now the `handle_info` only need to assign the new message to the socket:
   end
 ```
 
-Finally the heex messages template listen for any changes in the list of messages
-with `phx-update` and append the new message to the existing displayed list.
+Finally the heex messages template listens for any changes in the list of messages
+with `phx-update` and appends the new message to the existing displayed list.
 
 ```heex
 <ul id='msg-list' phx-update="append">

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ You should now have a functional chat application using liveView!
 
 ## Temporary assigns
 
-At the moment the `mount` function first initialise the list of messages
+At the moment the `mount` function first initialises the list of messages
 by loading the latest 20 messages from the database:
 
 ```elixir
@@ -520,7 +520,7 @@ end
 
 The list of messages is retrieved once, then it is reset to an empty list.
 
-Now the `handle_info` only need to assign the new message to the socket:
+Now the `handle_info` only needs to assign the new message to the socket:
 
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -473,6 +473,78 @@ Add the following tests to make sure that messages are correctly displayed on th
 
 You should now have a functional chat application using liveView!
 
+## Temporary assigns
+
+At the moment the `mount` function first initialise the list of messages
+by loading the latest 20 messsages from the database:
+
+```elixir
+def mount(_params, _session, socket) do
+  if connected?(socket), do: Message.subscribe()
+
+  messages = Message.list_messages() |> Enum.reverse() # get the list of messages
+  changeset = Message.changeset(%Message{}, %{})
+
+  {:ok, assign(socket, messages: messages, changeset: changeset)} ## assigns messages to socket
+end
+```
+
+Then each time a new message is created the `handle_info` function append
+the message to the list of messages:
+
+```elixir
+def handle_info({:message_created, message}, socket) do
+  messages = socket.assigns.messages ++ [message] # append new message to the existing list
+  {:noreply, assign(socket, messages: messages)}
+end
+```
+
+This can cause issues if the list of messages become long as
+all the messages are kept in memory on the server.
+
+To minimise the use of the memory we can define messages as a temporary assign:
+
+```elixir
+def mount(_params, _session, socket) do
+  if connected?(socket), do: Message.subscribe()
+
+  messages = Message.list_messages() |> Enum.reverse()
+  changeset = Message.changeset(%Message{}, %{})
+
+  {:ok, assign(socket, messages: messages, changeset: changeset),
+  temporary_assigns: [messages: []]}
+end
+
+```
+
+The list of messages is retrieved once, then it is reset to an empty list.
+
+Now the `handle_info` only need to assign the new message to the socket:
+
+
+```elixir
+  def handle_info({:message_created, message}, socket) do
+    {:noreply, assign(socket, messages: [message])}
+  end
+```
+
+Finally the heex messages template listen for any changes in the list of messages
+with `phx-update` and append the new message to the existing displayed list.
+
+```heex
+<ul id='msg-list' phx-update="append">
+   <%= for message <- @messages do %>
+     <li id={message.id}>
+       <b><%= message.name %>:</b>
+       <%= message.message %>
+     </li>
+   <% end %>
+</ul>
+```
+
+See also the Phoenix documentation page: 
+https://hexdocs.pm/phoenix_live_view/dom-patching.html#temporary-assigns
+
 ## What's next?
 
 If you found this example useful, please ⭐️ the GitHub repository

--- a/lib/liveview_chat_web/live/message_live.ex
+++ b/lib/liveview_chat_web/live/message_live.ex
@@ -7,7 +7,9 @@ defmodule LiveviewChatWeb.MessageLive do
 
     messages = Message.list_messages() |> Enum.reverse()
     changeset = Message.changeset(%Message{}, %{})
-    {:ok, assign(socket, messages: messages, changeset: changeset)}
+
+    {:ok, assign(socket, messages: messages, changeset: changeset),
+     temporary_assigns: [messages: []]}
   end
 
   def render(assigns) do
@@ -26,7 +28,6 @@ defmodule LiveviewChatWeb.MessageLive do
   end
 
   def handle_info({:message_created, message}, socket) do
-    messages = socket.assigns.messages ++ [message]
-    {:noreply, assign(socket, messages: messages)}
+    {:noreply, assign(socket, messages: [message])}
   end
 end

--- a/lib/liveview_chat_web/templates/message/message.html.heex
+++ b/lib/liveview_chat_web/templates/message/message.html.heex
@@ -1,4 +1,4 @@
-<ul id='msg-list'>
+<ul id='msg-list' phx-update="append">
    <%= for message <- @messages do %>
      <li id={message.id}>
        <b><%= message.name %>:</b>


### PR DESCRIPTION
ref: #5
Instead of keeping the list of messages in memory on the server and taking more memory when new messages are created, we use temporary assigns to reset the list of messages. The client will automatically append the messages to the initial list of messages.