### PR TITLE
Update coverage url to correct url project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # LiveviewChat
 
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/dwyl/phoenix-liveview-chat-example/Elixir%20CI?label=build&style=flat-square)](https://github.com/dwyl/phoenix-liveview-chat-example/actions/workflows/cy.yml)
-[![codecov test coverage](https://img.shields.io/codecov/c/github/dwyl/phoenix-liveview-chat-example/main.svg?style=flat-square)](http://codecov.io/github/dwyl/auth_plug?branch=main)
+[![codecov test coverage](https://img.shields.io/codecov/c/github/dwyl/phoenix-liveview-chat-example/main.svg?style=flat-square)](https://codecov.io/github/dwyl/phoenix-liveview-chat-example?branch=main)
 [![HitCount](http://hits.dwyl.com/dwyl/phoenix-liveview-chat-example.svg?style=flat-square)](http://hits.dwyl.com/dwyl/phoenix-liveview-chat-example)
   
 **Try it**: [**liveview-chat-example.herokuapp**](https://liveview-chat-example.herokuapp.com)


### PR DESCRIPTION
The codecov badge was creating a link to the wrong Github project.
Add new url to https://codecov.io/github/dwyl/phoenix-liveview-chat-example?branch=main